### PR TITLE
Ensure the greenlet timeout is longer than our asnyc timeout

### DIFF
--- a/greenlet_manager.py
+++ b/greenlet_manager.py
@@ -3,7 +3,14 @@ import logging
 
 import gevent
 
+import accurate_config as CONFIG
+
+GREENLET_TIMEOUT = CONFIG.async_timeout + CONFIG.async_interval + 120
+
 LOG = logging.getLogger(__name__)
+LOG.info("Async timeout = %s seconds", CONFIG.async_timeout)
+LOG.info("Async interval = %s seconds", CONFIG.async_interval)
+LOG.info("Greenlet timeout is %s seconds", GREENLET_TIMEOUT)
 
 
 class GreenletManager(list):
@@ -14,18 +21,21 @@ class GreenletManager(list):
             _instance.append(GreenletManager())
         return _instance[0]
 
-    def tracked_greenlet(self, f, timeout=10):
+    def tracked_greenlet(self, f):
         """A wrapper function that stores the current greenlet in list in order
         to keep track of our asynchronous request 'threads'. The greenlet
         remains in the list until it terminates, or until an explicit cleanup.
+
+        There is an implicit timeout on the runtime of greenlets. It is
+        computed automatically, and is guaranteed to be sufficiently longer
+        than than the async_timeout + async_interval.
 
         Usage:
             for _ in xrange(...):
                 # spawn
                 gevent.spawn(
                     greenlet_manager.tracked_greenlet,
-                    lambda: do_thing(arg, arg),
-                    timeout=10
+                    lambda: do_thing(arg, arg)
                 )
 
             # wait for greenlets to do a thing
@@ -39,7 +49,7 @@ class GreenletManager(list):
         try:
             current_greenlet = gevent.getcurrent()
             self.append(current_greenlet)
-            with gevent.Timeout(seconds=timeout) as timeout:
+            with gevent.Timeout(seconds=GREENLET_TIMEOUT):
                 f()
         except gevent.Timeout:
             # if the greenlet is killed externally don't print the exception


### PR DESCRIPTION
This fixes two issues:
- The external greenlet timeout defaults to 10 seconds. Testing this
  with an async timeout of < 10 seconds worked out well. But longer than
  10 seconds meant that greenlets doing async polling were killed early,
  and we would lose datapoints.
- Exceptions will occur on api calls (on bad statuses), during async
  polling loops. This may also have killed background greenlets too
  early.
